### PR TITLE
Run on pull request

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -2,7 +2,7 @@
 name: Run Python Tests
 
 on:
-  push:
+  pull_request:
     branches: [ main ]
 
 jobs:
@@ -25,5 +25,5 @@ jobs:
         run: |
           make venv
           make report
-          make test
+          make pytest
 ...


### PR DESCRIPTION
## Summary by Sourcery

Modify GitHub Actions workflow to run tests on pull requests instead of pushes

CI:
- Update test workflow to trigger on pull requests to the main branch instead of pushes

Tests:
- Change test command from 'make test' to 'make pytest' in the CI workflow